### PR TITLE
Using the hardhat.config.ts file generated by the npx hardhat command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,29 +1,20 @@
 {
-  "name": "hardhat-sample",
-  "version": "0.0.1",
+  "name": "godwoken-demo",
+  "version": "1.0.0",
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "hardhat test"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "keywords": [],
   "author": "",
-  "license": "MIT",
+  "license": "ISC",
   "devDependencies": {
-    "@ethersproject/abi": "^5.7.0",
-    "@ethersproject/providers": "^5.7.2",
-    "@nomicfoundation/hardhat-chai-matchers": "^2.0.2",
-    "@nomicfoundation/hardhat-network-helpers": "^1.0.9",
     "@nomicfoundation/hardhat-toolbox": "^3.0.0",
-    "@nomiclabs/hardhat-ethers": "^2.2.1",
-    "@nomiclabs/hardhat-etherscan": "^3.1.7",
-    "@openzeppelin/contracts": "^4.8.3",
-    "chai": "^4.3.7",
-    "ethers": "^6.2.3",
-    "hardhat": "^2.16.1",
-    "hardhat-gas-reporter": "^1.0.9",
-    "solidity-coverage": "^0.8.2"
+    "hardhat": "^2.17.3"
   },
   "dependencies": {
+    "@openzeppelin/contracts": "^4.9.3",
     "base64-sol": "^1.1.0"
   }
 }


### PR DESCRIPTION
1. I recommend referring to the [Setting up a project](https://hardhat.org/hardhat-runner/docs/guides/project-setup) guide and using the `hardhat.config.ts` generated by the `npx hardhat` command, to avoid various dependency issues with ethers.js, just like the ones encountered in your project.
```bash
sunchengzhu@sunchengzhudeMac-Studio godwoken-demo % npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR! 
npm ERR! While resolving: hardhat-sample@0.0.1
npm ERR! Found: ethers@6.7.1
npm ERR! node_modules/ethers
npm ERR!   dev ethers@"^6.2.3" from the root project
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer ethers@"^5.0.0" from @nomiclabs/hardhat-ethers@2.2.3
npm ERR! node_modules/@nomiclabs/hardhat-ethers
npm ERR!   dev @nomiclabs/hardhat-ethers@"^2.2.1" from the root project
npm ERR! 
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR! 
npm ERR! 
npm ERR! For a full report see:
npm ERR! /Users/sunchengzhu/.npm/_logs/2023-09-22T11_08_22_000Z-eresolve-report.txt

npm ERR! A complete log of this run can be found in: /Users/sunchengzhu/.npm/_logs/2023-09-22T11_08_22_000Z-debug-0.log
```
2. Please configure the private keys for the accounts and try again.
```bash
npx hardhat compile
npx hardhat run scripts/deploy.ts --network testnet
```